### PR TITLE
Update packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ This project provides a Streamlit-based interface to manage Python script tasks 
 To build a standalone EXE with PyInstaller:
 ```bash
 pip install pyinstaller
-pyinstaller --onefile app.py
+# include the templates directory so the XML template is bundled
+pyinstaller --onefile app.py --add-data "templates;templates"
 ```
-The resulting executable will be in the `dist` directory.
+The resulting executable will be in the `dist` directory with the
+`templates` folder packaged alongside the binary.
 
 ## Example XML Template
 See `templates/task_template.xml` for the base schedule task template used for creation.


### PR DESCRIPTION
## Summary
- expand README packaging section to show how to bundle templates when building the EXE

## Testing
- `python -m py_compile app.py preview.py scheduler_cli.py xml_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_6886dfbef944832b9b2f8544750d569f