### PR TITLE
Fix task XML encoding and refresh trigger form

### DIFF
--- a/templates/task_template.xml
+++ b/templates/task_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Date>{{ registration_date }}</Date>


### PR DESCRIPTION
## Summary
- ensure task XML template uses UTF-16 encoding
- write temporary XML file using UTF‑16
- store trigger type in session state to refresh form

## Testing
- `python -m py_compile app.py xml_builder.py scheduler_cli.py preview.py`

------
https://chatgpt.com/codex/tasks/task_e_6886e4488e1c832b96bf14054d893ffe